### PR TITLE
feat: support RELAYPLANE_PROXY_PORT and RELAYPLANE_PROXY_HOST env vars

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -846,9 +846,9 @@ async function main(): Promise<void> {
     process.exit(0);
   }
 
-  // Parse server options
-  let port = 4100;
-  let host = '127.0.0.1';
+  // Parse server options (env vars provide defaults, CLI flags override)
+  let port = parseInt(process.env.RELAYPLANE_PROXY_PORT ?? '4100', 10);
+  let host = process.env.RELAYPLANE_PROXY_HOST ?? '127.0.0.1';
   let verbose = false;
   let audit = false;
   let offline = false;


### PR DESCRIPTION
## Summary

- Adds environment variable support for `RELAYPLANE_PROXY_PORT` and `RELAYPLANE_PROXY_HOST` in `src/cli.ts`
- CLI flags (`--port`, `--host`) still override env vars
- Default values unchanged (port 4100, host 127.0.0.1)
- Enables container deployments to configure binding without CLI flags

## Changes

- `src/cli.ts`: Read `RELAYPLANE_PROXY_PORT` and `RELAYPLANE_PROXY_HOST` env vars as defaults

## Test plan

- [x] `npm run build` compiles cleanly
- [x] `RELAYPLANE_PROXY_PORT=4801 RELAYPLANE_PROXY_HOST=0.0.0.0 npm start` binds to correct port/host
- [x] `--port` and `--host` CLI flags still override env vars
- [x] Without env vars, defaults remain 4100/127.0.0.1