### PR TITLE
feat: add Dockerfile and .dockerignore for container deployments

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+.git
+.github
+__tests__
+coverage
+*.tsbuildinfo
+.env*
+.claude
+foundation
+CLAUDE.md
+.foundation-*
+vitest.config.ts

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,12 @@ RUN npm run build
 FROM node:18-alpine
 WORKDIR /app
 ENV NODE_ENV=production
-RUN addgroup -g 1000 relayplane && \
-    adduser -u 1000 -G relayplane -s /bin/sh -D relayplane
 COPY package.json package-lock.json* ./
 RUN npm ci --omit=dev --include=optional && npm cache clean --force
 COPY --from=builder /app/dist/ ./dist/
-RUN mkdir -p /home/relayplane/.relayplane && \
-    chown -R relayplane:relayplane /home/relayplane
-USER relayplane
+RUN mkdir -p /home/node/.relayplane && \
+    chown -R node:node /home/node/.relayplane
+USER node
 EXPOSE 4801
 ENV RELAYPLANE_PROXY_HOST=0.0.0.0
 ENV RELAYPLANE_PROXY_PORT=4801

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18-alpine AS builder
 WORKDIR /app
 COPY package.json package-lock.json* ./
-RUN npm ci --include=optional
+RUN if [ -f package-lock.json ]; then npm ci --include=optional; else npm install --include=optional; fi
 COPY tsconfig.json ./
 COPY src/ ./src/
 RUN npm run build
@@ -10,7 +10,7 @@ FROM node:18-alpine
 WORKDIR /app
 ENV NODE_ENV=production
 COPY package.json package-lock.json* ./
-RUN npm ci --omit=dev --include=optional && npm cache clean --force
+RUN if [ -f package-lock.json ]; then npm ci --omit=dev --include=optional; else npm install --omit=dev --include=optional; fi && npm cache clean --force
 COPY --from=builder /app/dist/ ./dist/
 RUN mkdir -p /home/node/.relayplane && \
     chown -R node:node /home/node/.relayplane

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:18-alpine AS builder
+WORKDIR /app
+COPY package.json package-lock.json* ./
+RUN npm ci --include=optional
+COPY tsconfig.json ./
+COPY src/ ./src/
+RUN npm run build
+
+FROM node:18-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+RUN addgroup -g 1000 relayplane && \
+    adduser -u 1000 -G relayplane -s /bin/sh -D relayplane
+COPY package.json package-lock.json* ./
+RUN npm ci --omit=dev --include=optional && npm cache clean --force
+COPY --from=builder /app/dist/ ./dist/
+RUN mkdir -p /home/relayplane/.relayplane && \
+    chown -R relayplane:relayplane /home/relayplane
+USER relayplane
+EXPOSE 4801
+ENV RELAYPLANE_PROXY_HOST=0.0.0.0
+ENV RELAYPLANE_PROXY_PORT=4801
+ENTRYPOINT ["node", "dist/cli.js"]


### PR DESCRIPTION
## Summary

- Adds multi-stage Dockerfile for building and running the proxy in containers
- Adds `.dockerignore` to minimize build context
- Uses existing `node` user (UID 1000) for non-root execution
- Sets container defaults: port 4801, host 0.0.0.0 via env vars

## Changes

- `Dockerfile` (new): Multi-stage build (builder + runtime), conditional `npm ci`/`npm install` for lockfile flexibility
- `.dockerignore` (new): Excludes node_modules, dist, .git, tests, config files

## Dockerfile details

- **Builder stage**: Installs all deps, compiles TypeScript
- **Runtime stage**: Production deps only, non-root `node` user
- **Port**: 4801 (via `RELAYPLANE_PROXY_PORT` env var, requires PR #3)
- **Entrypoint**: `node dist/cli.js`

## Test plan

- [x] `docker build -t relayplane-proxy .` succeeds
- [x] `docker run -e ANTHROPIC_API_KEY=... -p 4801:4801 relayplane-proxy` starts and `/health` responds
- [x] Runs as non-root (UID 1000)
- [x] Build context is minimal (~50KB without node_modules/dist)

## Dependencies

- Works best with RelayPlane/proxy#3 (env var support for port/host)