### PR TITLE
Fix wildcard CORS, restrict credential file permissions, add body size limit

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -242,7 +242,7 @@ function generateDeviceId(): string {
  */
 function ensureConfigDir(): void {
   if (!fs.existsSync(CONFIG_DIR)) {
-    fs.mkdirSync(CONFIG_DIR, { recursive: true });
+    fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
   }
 }
 
@@ -384,9 +384,9 @@ export function saveConfig(config: ProxyConfig): void {
     }
   }
   
-  // Atomic write: write to tmp, then rename
+  // Atomic write: write to tmp with restricted permissions, then rename
   const data = JSON.stringify(config, null, 2);
-  fs.writeFileSync(CONFIG_TMP, data);
+  fs.writeFileSync(CONFIG_TMP, data, { mode: 0o600 });
   fs.renameSync(CONFIG_TMP, CONFIG_FILE);
 }
 
@@ -459,7 +459,7 @@ export function setApiKey(key: string): void {
       creds = JSON.parse(fs.readFileSync(credPath, 'utf-8'));
     }
     creds.apiKey = key;
-    fs.writeFileSync(credPath, JSON.stringify(creds, null, 2));
+    fs.writeFileSync(credPath, JSON.stringify(creds, null, 2), { mode: 0o600 });
   } catch {}
 }
 

--- a/src/credentials.ts
+++ b/src/credentials.ts
@@ -77,12 +77,12 @@ export function saveAgentCredentials(creds: Partial<AgentCredentials>): void {
   const dir = path.dirname(credPath);
 
   if (!fs.existsSync(dir)) {
-    fs.mkdirSync(dir, { recursive: true });
+    fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
   }
 
   const existing = loadAgentCredentials();
   const merged: AgentCredentials = { ...existing, ...creds };
-  fs.writeFileSync(credPath, JSON.stringify(merged, null, 2) + '\n');
+  fs.writeFileSync(credPath, JSON.stringify(merged, null, 2) + '\n', { mode: 0o600 });
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -404,8 +404,12 @@ export class ProxyServer {
   private async handleRequest(req: http.IncomingMessage, res: http.ServerResponse): Promise<void> {
     const url = new URL(req.url ?? '/', `http://${req.headers.host}`);
 
-    // CORS headers
-    res.setHeader('Access-Control-Allow-Origin', '*');
+    // CORS headers — restrict to localhost origins to prevent cross-site data exfiltration
+    const origin = req.headers.origin as string | undefined;
+    const allowedOrigins = ['http://localhost:4100', 'http://localhost:3000', 'http://127.0.0.1:4100', 'http://127.0.0.1:3000'];
+    if (origin && allowedOrigins.includes(origin)) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+    }
     res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
     res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-RelayPlane-Workspace, X-RelayPlane-Agent, X-RelayPlane-Session, X-RelayPlane-Automated');
 
@@ -1370,13 +1374,25 @@ export class ProxyServer {
     );
   }
 
+  /** Maximum request body size (1 MB) */
+  private static readonly MAX_BODY_SIZE = 1_048_576;
+
   /**
-   * Read request body
+   * Read request body with size limit to prevent memory exhaustion from oversized payloads.
    */
   private readBody(req: http.IncomingMessage): Promise<string> {
     return new Promise((resolve, reject) => {
       let body = '';
-      req.on('data', (chunk) => (body += chunk));
+      let size = 0;
+      req.on('data', (chunk: Buffer | string) => {
+        size += typeof chunk === 'string' ? Buffer.byteLength(chunk) : chunk.length;
+        if (size > ProxyServer.MAX_BODY_SIZE) {
+          req.destroy();
+          reject(new Error('Request body exceeds 1 MB size limit'));
+          return;
+        }
+        body += chunk;
+      });
       req.on('end', () => resolve(body));
       req.on('error', reject);
     });


### PR DESCRIPTION
## Summary

Three quick security hardening fixes that address vulnerabilities in how the proxy handles CORS, stores credentials, and accepts request bodies.

### 1. Replace wildcard CORS with localhost allowlist

**File:** `src/server.ts`

The proxy currently sets `Access-Control-Allow-Origin: *` on every response. This means **any website** can make cross-origin requests to the proxy and read the responses — including sensitive endpoints like `/v1/budget`, `/v1/runs/{id}`, `/v1/policies`, and `/v1/simulate/*` which return cost data, routing decisions, and policy evaluations.

**Attack scenario:** A user visits a malicious webpage. JavaScript on that page fetches `http://localhost:4100/v1/budget` and silently exfiltrates the user's budget state, run traces, and policy configuration.

**Fix:** Replace `*` with an explicit allowlist of localhost origins (`localhost:4100`, `localhost:3000`, and `127.0.0.1` equivalents). The `Access-Control-Allow-Origin` header is only set when the request's `Origin` matches the allowlist. Cross-origin requests from non-localhost origins are blocked by the browser's same-origin policy.

### 2. Restrict credential and config file permissions to owner-only

**Files:** `src/credentials.ts`, `src/config.ts`

`credentials.json` and `config.json` (which can contain `api_key`) are written with Node's default file permissions (typically `0644` on Unix), making them **readable by any local user**. The `.relayplane/` directory is also created with default permissions.

**Attack scenario:** On a shared system (CI runner, dev server, multi-user workstation), any user can `cat ~/.relayplane/credentials.json` and steal API keys for Anthropic, OpenAI, or other providers.

**Fix:**
- Create `~/.relayplane/` directory with mode `0700` (owner-only access)
- Write `credentials.json` and `config.json` with mode `0600` (owner read/write only)
- Applied consistently across all write paths: `saveAgentCredentials()`, `saveConfig()`, and `setApiKey()`

### 3. Add 1 MB request body size limit

**File:** `src/server.ts`

The `readBody()` helper accumulates the request body with `body += chunk` without any size check. All POST endpoints that parse JSON bodies (`/v1/policies/test`, `/v1/simulate/policy`, `/v1/simulate/routing`, `/v1/chat/completions`, etc.) are vulnerable.

**Attack scenario:** An attacker sends a multi-gigabyte POST body to any endpoint, exhausting server memory and crashing the proxy (OOM).

**Fix:** Track accumulated byte size in `readBody()` and destroy the request with a clear error message if it exceeds 1 MB. The limit is defined as a static class constant (`MAX_BODY_SIZE`) for easy adjustment.

## Test plan

- [x] TypeScript compiles clean (`npx tsc --noEmit` — zero errors)
- [x] Full test suite: 802 passed, 40 failed (all failures are pre-existing: missing optional deps like `@relayplane/learning-engine`, missing `tsx` binary — unrelated to these changes)
- [x] Middleware tests pass (5/5) — confirms proxy request handling still works
- [ ] Manual: verify the dashboard at `localhost:4100` still loads (CORS allows `localhost:4100`)
- [ ] Manual: verify a cross-origin fetch from a different origin is blocked
- [ ] Manual: verify sending a >1MB POST body returns a clear error instead of hanging
- [ ] Manual: verify `~/.relayplane/credentials.json` is created with `600` permissions on a fresh setup